### PR TITLE
Get rid of default :parameters field for Path in v2.

### DIFF
--- a/lib/swagger/v2/path.rb
+++ b/lib/swagger/v2/path.rb
@@ -15,11 +15,6 @@ module Swagger
       end
       field :parameters, Array[Parameter]
 
-      def initialize(hash)
-        hash[:parameters] ||= []
-        super
-      end
-
       def operations
         VERBS.each_with_object({}) do | v, h |
           operation = send v


### PR DESCRIPTION
This parameters field is not a required field, and it can cause issues if you don't actually want it in your swagger.