### PR TITLE
Get rid of default :parameters field in path.

### DIFF
--- a/lib/swagger/v2/path.rb
+++ b/lib/swagger/v2/path.rb
@@ -15,11 +15,6 @@ module Swagger
       end
       field :parameters, Array[Parameter]
 
-      def initialize(hash)
-        hash[:parameters] ||= []
-        super
-      end
-
       def operations
         VERBS.each_with_object({}) do |v, h|
           operation = send v

--- a/spec/swagger/v2/path_spec.rb
+++ b/spec/swagger/v2/path_spec.rb
@@ -1,0 +1,15 @@
+require 'spec_helper'
+
+module Swagger
+  module V2
+    describe Path do
+      subject(:path) { Path.new({}) }
+      describe 'initial fields' do
+        describe '#parameters' do
+          subject { path.parameters }
+          it { is_expected.to eq(nil) }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The default empty array value for the :parameters field in the V2::Path object can cause validation issues and is not required.
