### PR TITLE
Loosen mime-types versioning

### DIFF
--- a/swagger-core.gemspec
+++ b/swagger-core.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'addressable', '~> 2.3'
   spec.add_dependency 'hashie', '~> 3.0', '< 3.4.0'
   spec.add_dependency 'json-schema', '~> 2.2'
-  spec.add_dependency 'mime-types', '~> 2.0'
+  spec.add_dependency 'mime-types', '>= 1.16', '~> 2.0'
   spec.add_development_dependency 'bundler', '~> 1.5'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'


### PR DESCRIPTION
I sort of need this for a project I'm working on. I chose `1.16` based on the locking for Rails 3.2:

```
    rails (= 3.2.22.2) was resolved to 3.2.22.2, which depends on
      actionmailer (= 3.2.22.2) was resolved to 3.2.22.2, which depends on
        mail (~> 2.5.4) was resolved to 2.5.4, which depends on
          mime-types (~> 1.16)

```

Thanks!
