### PR TITLE
Adds support for conditionally required fields for SecurityScheme

### DIFF
--- a/lib/swagger/v2/security_scheme.rb
+++ b/lib/swagger/v2/security_scheme.rb
@@ -6,6 +6,10 @@ module Swagger
     # @see https://github.com/swagger-api/swagger-spec/blob/master/versions/2.0.md#securitySchemeObject
     #   Security Scheme Object
     class SecurityScheme < SwaggerObject
+      OAUTH2_TYPE = 'oauth'.freeze
+      API_KEY_TYPE = 'apikey'.freeze
+      FLOW_TYPES_REQUIRING_AUTHORIZATION_URL = %w(implicit accesscode).freeze
+      FLOW_TYPES_REQUIRING_TOKEN_URL = %w(password application accesscode).freeze
       # FIXME: Swagger documentation about what's required doesn't seem accurate - OSAuth2 centric?
 
       # According to docs, all except description are required. Schema and samples don't match.
@@ -13,13 +17,38 @@ module Swagger
       # @!group Fixed Fields
       required_field :type, String
       field :description, String
-      field :name, String
-      field :in, String
-      required_field :flow, String
-      required_field :authorizationUrl, String
-      field :tokenUrl, String
-      required_field :scopes, Hash
+
+      # Fields required for type apiKey
+      field :name, String, required: :api_key?
+      field :in, String, required: :api_key?
+
+      # Fields required for type oauth2
+      field :flow, String, required: :oauth2?
+      field :scopes, Hash, required: :oauth2?
+
+      # Fields required for oauth 2 for certain flow types
+      field :authorizationUrl, String, required: :requires_authorization_url?
+      field :tokenUrl, String, required: :requires_token_url?
       # @!endgroup
+
+      private
+
+      def oauth2?
+        type.to_s.downcase == OAUTH2_TYPE
+      end
+
+      def api_key?
+        type.to_s.downcase == API_KEY_TYPE
+      end
+
+      def requires_authorization_url?
+        oauth2? &&
+          FLOW_TYPES_REQUIRING_AUTHORIZATION_URL.include?(flow.to_s.downcase)
+      end
+
+      def requires_token_url?
+        oauth2? && FLOW_TYPES_REQUIRING_TOKEN_URL.include?(flow.to_s.downcase)
+      end
     end
   end
 end


### PR DESCRIPTION
We were trying to use this for some work we were doing and we were failing on the validations. It's funny since we didn't really care about the validations, we just wanted an already-built-parser for Swagger docs of both types. Ran into this problem, decided to put out a pull request. Aims to fix #10.
