### PR TITLE
Unlock mime-types version

### DIFF
--- a/lib/swagger/v2/security_scheme.rb
+++ b/lib/swagger/v2/security_scheme.rb
@@ -12,13 +12,13 @@ module Swagger
 
       # @!group Fixed Fields
       required_field :type, String
-      field :description, String
+      required_field :description, String
       field :name, String
       field :in, String
-      required_field :flow, String
-      required_field :authorizationUrl, String
+      field :flow, String
+      field :authorizationUrl, String
       field :tokenUrl, String
-      required_field :scopes, Hash
+      field :scopes, Hash
       # @!endgroup
     end
   end

--- a/swagger-core.gemspec
+++ b/swagger-core.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'addressable', '~> 2.3'
   spec.add_dependency 'hashie', '~> 3.0', '< 3.4.0'
   spec.add_dependency 'json-schema', '~> 2.2'
-  spec.add_dependency 'mime-types', '~> 2.0'
+  spec.add_dependency 'mime-types'
   spec.add_development_dependency 'bundler', '~> 1.5'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'


### PR DESCRIPTION
Hi @maxlinc,

swagger-core is compatible with mime-types `1.x` and `3.x`.