### PR TITLE
Adds require forwardable to mime_types.rb.

### DIFF
--- a/lib/swagger/mime_type.rb
+++ b/lib/swagger/mime_type.rb
@@ -1,4 +1,5 @@
 require 'mime/types'
+require 'forwardable'
 
 module Swagger
   # Class representing Media Types (commonly known as MIME Types).


### PR DESCRIPTION
Was getting this error from Ruby 1.9.3 while trying to use this gem.

```
C:/Ruby21/lib/ruby/gems/2.1.0/gems/swagger-core-0.2.3/lib/swagger/mime_type.rb:7:in `<class:MimeType>': uninitialized constant Swagger::MimeType::Forwardable (NameErro)
        from C:/Ruby21/lib/ruby/gems/2.1.0/gems/swagger-core-0.2.3/lib/swagger/mime_type.rb:6:in `<module:Swagger>'
        from C:/Ruby21/lib/ruby/gems/2.1.0/gems/swagger-core-0.2.3/lib/swagger/mime_type.rb:3:in `<top (required)>'
        from C:/Ruby21/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:68:in `require'
        from C:/Ruby21/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:68:in `require'
        from C:/Ruby21/lib/ruby/gems/2.1.0/gems/swagger-core-0.2.3/lib/swagger.rb:53:in `<top (required)>'
        from C:/Ruby21/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:133:in `require'
        from C:/Ruby21/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:133:in `rescue in require'
        from C:/Ruby21/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:40:in `require'
        from D:/git/lambda_wrap-shockolate/lib/lambda_wrap.rb:7:in `<top (required)>'
```
