### PR TITLE
Sets upper limit of Addressable to continue supporting 1.9.3.

### DIFF
--- a/swagger-core.gemspec
+++ b/swagger-core.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(/^(test|spec|features)\//)
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'addressable', '~> 2.3'
+  spec.add_dependency 'addressable', ['>= 2.3.0', '< 2.5.0']
   spec.add_dependency 'hashie', '~> 3.0', '< 3.4.0'
   spec.add_dependency 'json-schema', '~> 2.2'
   spec.add_dependency 'mime-types'


### PR DESCRIPTION
The Addressable Gem has dropped 1.9.x support in version 2.5.0

Or, set the Required Ruby Version in the .gemspec